### PR TITLE
Use the proper fields for address (to force it to São Paulo)

### DIFF
--- a/app/assets/javascripts/marcadores.js
+++ b/app/assets/javascripts/marcadores.js
@@ -478,7 +478,11 @@ $(document).ready(function(){
             {
                 format: "json",
                 limit: 1,
-                q: $('#text_busca').val() + ", São Paulo - SP, Brazil"
+                street: $('#text_busca').val(),
+                city: "São Paulo",
+                state: "SP",
+                country: "Brazil"
+
             },
             function(data) {
               result = data["0"];


### PR DESCRIPTION
Improves the address search by specifying the city/state/country in their own fields, and putting the text search in the "street" field.

Fixes #19 (as much as I can for now, at least)